### PR TITLE
Fixed game crashing when game files failed to load

### DIFF
--- a/rttr-de.po
+++ b/rttr-de.po
@@ -3590,8 +3590,8 @@ msgid ""
 "%1%"
 msgstr ""
 "Einige Dateien konnten nicht geladen werden.\n"
-"Bitte prüfe ob Die Siedler II Gold-Edition im gleichen \n"
-"Verzeichnis wie Return to the Roots installiert ist."
+"Bitte prüfe ob Die Siedler II Gold-Edition in folgendem Verzeichnis installiert ist\n"
+"%1%"
 
 #: libs/s25main/desktops/dskDirectIP.cpp:45 libs/s25main/desktops/dskLAN.cpp:83
 #: libs/s25main/desktops/dskLAN.cpp:164 libs/s25main/desktops/dskLobby.cpp:122


### PR DESCRIPTION
The translation needed "%1%" to work with boost. Without "%1%" it would just crash without an error message