### PR TITLE
Fix message that causes s25client Test_Integration failure

### DIFF
--- a/rttr-pl.po
+++ b/rttr-pl.po
@@ -2380,7 +2380,7 @@ msgstr "Delegat ładowania Lua zwrócił błąd!"
 #: libs/libGamedata/lua/CampaignDataLoader.cpp:47
 #: libs/s25main/lua/LuaInterfaceGameBase.cpp:54
 msgid "Lua script did not provide the function getRequiredLuaVersion()! It is probably outdated.\n"
-msgstr "Skrypt Lua nie udostępnił funkcji getRequiredLuaVersion ()! Prawdopodobnie jest nieaktualny.\n"
+msgstr "Skrypt Lua nie udostępnił funkcji getRequiredLuaVersion()! Prawdopodobnie jest nieaktualny.\n"
 
 #: libs/s25main/world/MapSerializer.cpp:181
 msgid "Lua script failed to load."


### PR DESCRIPTION
Unnecessary space between function name and the brackets causes s25client/Test_Integration failure when run on a Windows PC with Polish regional settings.